### PR TITLE
Making it compile for Java > 1.3 (Generics support)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,6 @@ target
 *~
 .DS_Store
 
+## Intellij iDEA
+.idea/
+*iml

--- a/pom.xml
+++ b/pom.xml
@@ -16,6 +16,19 @@
     </dependency>-->
 
     </dependencies>
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-compiler-plugin</artifactId>
+                <version>3.2</version>
+                <configuration>
+                    <source>1.7</source>
+                    <target>1.7</target>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
     
 
 </project>


### PR DESCRIPTION
Because on compilation using Maven the next error pops-up I've added the corresponding properties to maven compiler plugin

```
  sqlf/src/main/java/net/whiteants/util/FormatProcess.java:[21,22] error: generics are not supported in -source 1.3
```

PS: Sorry for not contacting you via e-mail or else but have no way to do so, not from your GitHub user page.
